### PR TITLE
Blocksize straight from AES

### DIFF
--- a/django_twofactor/encutil.py
+++ b/django_twofactor/encutil.py
@@ -15,6 +15,8 @@ try:
 except ImportError:
     from django_twofactor import pyaes as AES
 
+BLOCK_SIZE = AES.block_size
+
 # Get best `random` implementation we can.
 import random
 try:
@@ -35,8 +37,8 @@ def encrypt(data, salt):
     cipher = AES.new(_get_key(salt), mode=AES.MODE_ECB)
     value = smart_str(data)
 
-    padding  = cipher.block_size - len(value) % cipher.block_size
-    if padding and padding < cipher.block_size:
+    padding  = BLOCK_SIZE - len(value) % BLOCK_SIZE
+    if padding and padding < BLOCK_SIZE:
         value += "\0" + ''.join([random.choice(string.printable) for index in range(padding-1)])
     return hexlify(cipher.encrypt(value))
 


### PR DESCRIPTION
Fetch blocksize straight from AES. This improves compatibility with pycryptodome

What was tested
==================
enable, use and disable 2fa in bitcoinxcash with django 1.8 and 1.11, and with pycrypto, pyaes and pycryptodome

Test
================
The above